### PR TITLE
What is CI? ci.debian.net? Took me some time

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ QPDF is known to build and pass its test suite with mingw (latest version tested
 
 # Building Documentation
 
-The QPDF manual is written in reStructured Text format and is build with [sphinx](https://www.sphinx-doc.org). The sources to the user manual can be found in the `manual` directory. For more detailed information, consult the [Building and Installing QPDF section of the manual](manual/installation.rst) or consult the [build-doc script used in CI](build-scripts/build-doc).
+The QPDF manual is written in reStructured Text format and is build with [sphinx](https://www.sphinx-doc.org). The sources to the user manual can be found in the `manual` directory. For more detailed information, consult the [Building and Installing QPDF section of the manual](manual/installation.rst) or consult the [build-doc script used in CI](build-scripts/build-doc). (CI is [Debian Continuous Integration](https://ci.debian.net/))
 
 # Additional Notes on Build
 


### PR DESCRIPTION
I hope I am not the only one wondering what CI is. Finding that out was not a quick search. Do other people find it more quickly? And I am still not sure it is what this patch refers to. Do give a hint about that, or use the full term, or apply the patch, or something. Thank you.
Should it be 
`( CI is [Debian Continuous Integration](https://ci.debian.net/) )`
with some white space before, and after, the external parenthesis?